### PR TITLE
13 offscreen english

### DIFF
--- a/SolderingPen_ESP32S2/Languages.h
+++ b/SolderingPen_ESP32S2/Languages.h
@@ -96,7 +96,7 @@ const char *MaxTipMessage[][language_types] = { "警告", "警告", "Warning",
                                                 "最大数量", "最大數量", "maximum number",
                                                 "的烙铁头!", "的烙鐵頭!", "of tips!" };
 
-const char *txt_set_temp[] = { "设温:", "設溫:", "SET:" };
+const char *txt_set_temp[] = { "设温:", "設溫:", ">" };
 const char *txt_error[] = { "错误", "錯誤", "ERROR" };
 const char *txt_off[] = { "关闭", "關閉", "OFF" };
 const char *txt_sleep[] = { "休眠", "休眠", "SLEEP" };

--- a/SolderingPen_ESP32S2/SolderingPen_ESP32S2.ino
+++ b/SolderingPen_ESP32S2/SolderingPen_ESP32S2.ino
@@ -694,20 +694,41 @@ void MainScreen() {
 
     // draw status of heater 绘制加热器状态
     u8g2.setCursor(96, 0 + SCREEN_OFFSET);
-    if (ShowTemp > 500)
+    if (ShowTemp > 500){
+      if(language == 2)
+        u8g2.setCursor(78, 0 + SCREEN_OFFSET);
       u8g2.print(txt_error[language]);
-    else if (inOffMode || inLockMode)
+    }
+    else if(inOffMode || inLockMode){
+      if(language == 2)
+        u8g2.setCursor(96, 0 + SCREEN_OFFSET);
       u8g2.print(txt_off[language]);
-    else if (inSleepMode)
+    }
+    else if (inSleepMode){
+      if(language == 2)
+        u8g2.setCursor(78, 0 + SCREEN_OFFSET);
       u8g2.print(txt_sleep[language]);
-    else if (inBoostMode)
+    }
+    else if (inBoostMode){
+      if(language == 2)
+        u8g2.setCursor(74, 0 + SCREEN_OFFSET);
       u8g2.print(txt_boost[language]);
-    else if (isWorky)
+    }
+    else if (isWorky){
+      if(language == 2)
+        u8g2.setCursor(81, 0 + SCREEN_OFFSET);
       u8g2.print(txt_worky[language]);
-    else if (Output < 180)
+    }
+    else if (Output < 180){
+      if(language == 2)
+        u8g2.setCursor(86, 0 + SCREEN_OFFSET);
       u8g2.print(txt_on[language]);
-    else
+    }
+    else{
+      if(language == 2)
+        u8g2.setCursor(86, 0 + SCREEN_OFFSET);
       u8g2.print(txt_hold[language]);
+    }
 
     // rest depending on main screen type 休息取决于主屏幕类型
     if (MainScrType) {
@@ -723,7 +744,10 @@ void MainScreen() {
       u8g2.setCursor(0, 50);
       u8g2.print(lastSENSORTmp, 1);
       u8g2.print(F("C"));
-      u8g2.setCursor(83, 50);
+      if(fVin >= 10.0)
+        u8g2.setCursor(79, 50);
+      else
+        u8g2.setCursor(88, 50);
       u8g2.print(fVin, 1);
       u8g2.print(F("V"));
       // draw current temperature 绘制当前温度

--- a/SolderingPen_ESP32S2/SolderingPen_ESP32S2.ino
+++ b/SolderingPen_ESP32S2/SolderingPen_ESP32S2.ino
@@ -686,7 +686,10 @@ void MainScreen() {
     u8g2.setFontPosTop();
     //    u8g2.drawUTF8(0, 0 + SCREEN_OFFSET, "设温:");
     u8g2.drawUTF8(0, 0 + SCREEN_OFFSET, txt_set_temp[language]);
-    u8g2.setCursor(40, 0 + SCREEN_OFFSET);
+    if(language == 2)
+      u8g2.setCursor(8, 0 + SCREEN_OFFSET);
+    else
+      u8g2.setCursor(40, 0 + SCREEN_OFFSET);
     u8g2.print(Setpoint, 0);
 
     // draw status of heater 绘制加热器状态

--- a/SolderingPen_ESP32S2/SolderingPen_ESP32S2.ino
+++ b/SolderingPen_ESP32S2/SolderingPen_ESP32S2.ino
@@ -549,9 +549,11 @@ void SENSORCheck() {
   if ((ShowTemp != Setpoint) || (abs(ShowTemp - CurrentTemp) > 5))
     ShowTemp = CurrentTemp;
   if (abs(ShowTemp - Setpoint) <= 1) ShowTemp = Setpoint;
-  if (inLockMode) {
-    ShowTemp = 0;
-  }
+  
+  // Don't show fake 0 for temp. Tip can still be very hot after reboot.
+  // if (inLockMode) {
+  //   ShowTemp = 0;
+  // }
 
   // set state variable if temperature is in working range; beep if working
   // temperature was just reached


### PR DESCRIPTION
- English "SET:" is repalced with a ">" to give more space for longer status messages
- English status messages are aligned depending on text content.
- Don't show fake 0 (000) temp at startup. Soldering tip still can be very hot after a reboot.