### PR TITLE
Issue 19 fix - Doesn't save temp settings

### DIFF
--- a/SolderingPen_ESP32S2/SolderingPen_ESP32S2.ino
+++ b/SolderingPen_ESP32S2/SolderingPen_ESP32S2.ino
@@ -748,7 +748,6 @@ void MainScreen() {
 void SetupScreen() {
   ledcWrite(CONTROL_CHANNEL, HEATER_OFF);  // shut off heater
   beep();
-  uint16_t SaveSetTemp = SetTemp;
   uint8_t selection = 0;
   bool repeat = true;
 
@@ -837,7 +836,7 @@ void SetupScreen() {
   }
   updateEEPROM();
   handleMoved = true;
-  SetTemp = SaveSetTemp;
+  SetTemp = DefaultTemp;
   setRotary(TEMP_MIN, TEMP_MAX, TEMP_STEP, SetTemp);
 }
 


### PR DESCRIPTION
https://github.com/Eddddddddy/Songguo-PTS200/issues/19

This part causes it at line 612 in **Thermostat()** function:
```
if (SetTemp != DefaultTemp) {
    DefaultTemp = SetTemp;  // 把设置里面的默认温度也修改了
    update_default_temp_EEPROM();
}
```
When user finishes setting up things, and exists to main screen, then **updateEEPROM()** is called, which saves everything correctly. Even DefaultTemp too!
Now normal operation starts, Thermostat() called from loop, but SetTemp won't be equal to DefaultTemp, so DefaultTemp is overwitten with SetTemp, then it is also saved in eeprom. Which is wrong, because it overwrites user's previous DefaultTemp modification.

My fix:
- In **SetupScreen()** function there is no reason to store **SetTemp** value into **SaveSetTemp** variable, then in the end write it back. Nothing changes **SetTemp** within this part.
- But if user changed **DefaultTemp** then we have to save it to **SetTemp** too. Because **Thermostat()** function will be called, and it would overwrite user's previous setting.